### PR TITLE
Bump up teradata-nodejs-driver version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,12 +46,11 @@
   "dependencies": {
     "@sqltools/base-driver": "latest",
     "@sqltools/types": "latest",
-    "@teradataprebuilt/nativelib-win32": "^1.0.0-beta.1",
     "ffi-napi": "^4.0.3",
     "keytar": "^7.7.0",
     "node-gyp": "^8.2.0",
     "ref-array-di": "^1.2.2",
-    "teradata-nodejs-driver": "^1.0.0-rc.2",
+    "teradata-nodejs-driver": "^1.0.0-rc.5",
     "uuid": "^7.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
We have just released teradata-nodejs-driver 1.0.0-rc.5. It makes no assumptions about the directory structure when looking for @teradataprebuilt/nativelib. Also, @teradataprebuilt/nativelib no longer has to be listed as an explicit dependency of the app.