### PR TITLE
Add GH action for deployments to VS marketplace

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,7 +45,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: build
-    if: success() && ${{ github.events.inputs && (github.event.inputs.publish == 'true') }}
+    if: github.event.inputs && (github.event.inputs.publish == 'true')
     steps:
       - uses: actions/download-artifact@v2
       - run: npx vsce publish --packagePath $(find . -iname *.vsix)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,8 +29,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
-      - run: npm install
+          node-version: 16
+          cache: npm
+      - run: echo $NODE_HEADERS_INCLUDE_DIR && npm install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           npm_config_arch: ${{ matrix.npm_config_arch }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,53 @@
+name: CI
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish?'
+        required: false
+        default: 'false'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            platform: win32
+            arch: x64
+            npm_config_arch: x64
+          - os: ubuntu-latest
+            platform: linux
+            arch: x64
+            npm_config_arch: x64
+          - os: macos-latest
+            platform: darwin
+            arch: x64
+            npm_config_arch: x64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+      - run: npm install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          npm_config_arch: ${{ matrix.npm_config_arch }}
+      - shell: pwsh
+        run: echo "target=${{ matrix.platform }}-${{ matrix.arch }}" >> $env:GITHUB_ENV
+      - run: npx vsce package --target ${{ env.target }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.target }}
+          path: "*.vsix"
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: success() && ${{ github.events.inputs && (github.event.inputs.publish == 'true') }}
+    steps:
+      - uses: actions/download-artifact@v2
+      - run: npx vsce publish --packagePath $(find . -iname *.vsix)
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CD
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 16.x
       - run: npm install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2020 by Teradata. All rights reserved. http://teradata.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sqltools-teradata-driver",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR adds a GH Actions workflow for publishing to VS marketplace. For now, the workflow needs to be triggered manually. To trigger manually, go to https://github.com/scriptpup/sqltools-teradata-driver/actions/workflows/cd.yml and press "Run workflow". You will see a dialog where you can say if you want to publish (instead of only packaging):
![image](https://user-images.githubusercontent.com/6579240/141369122-024fd504-9ed6-4c2c-ba38-802d58d16dd9.png)

I recommend you first package only and see how it runs. The build will produce 3 artifacts that you can download from Actions tab:
![image](https://user-images.githubusercontent.com/6579240/141369199-6dd038fc-c966-4406-b754-93af1677c3b0.png)

To setup the publishing step you need to add your VS Marketplace PAT to GitHub secrets using VSCE_PAT as the secret's key. 

NOTE: sometimes the windows build fails. It looks like it has something to do with how actions/setup-node restores state from cache. I don't know of any workaround apart from trying the build again.