### PR TITLE
Upgrade build dependencies, add support for Darwin arm64

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,29 +15,40 @@ jobs:
           - os: windows-latest
             platform: win32
             arch: x64
-            npm_config_arch: x64
           - os: ubuntu-latest
             platform: linux
             arch: x64
-            npm_config_arch: x64
           - os: macos-latest
             platform: darwin
             arch: x64
-            npm_config_arch: x64
+          - os: macos-latest
+            platform: darwin
+            arch: arm64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
-      - run: npm i -g node-gyp          
+          node-version: 20.11.1 # we need to be very specific here due to https://github.com/nodejs/node/issues/52240
+      - shell: pwsh
+        run: |
+          if ($IsLinux) {
+            python3 -m pip install setuptools
+          }
+          elseif ($IsMacOS) {
+            brew install python-setuptools
+          }
+          elseif ($IsWindows) {
+            python3 -m pip install setuptools
+          }
+      - run: npm i -g node-gyp
       - run: npm install
         env:
-          npm_config_arch: ${{ matrix.npm_config_arch }}
+          npm_config_arch: ${{ matrix.arch }}
       - shell: pwsh
         run: echo "target=${{ matrix.platform }}-${{ matrix.arch }}" >> $env:GITHUB_ENV
       - run: npx vsce package --target ${{ env.target }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ env.target }}
           path: "*.vsix"
@@ -47,7 +58,7 @@ jobs:
     needs: build
     if: github.event.inputs && (github.event.inputs.publish == 'true')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
       - run: npx vsce publish --packagePath $(find . -iname *.vsix)
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
I've noticed that the recent build had wrong `ffi_bindings.node` file. For example, the Darwin build had `ffi_bindings.node` for linux. I've updated the dependencies in the build file, upgraded node, did some other fixes. I've built in my fork and validated the resultant binaries.

Could you please merge and trigger CD to republish the extension?