### PR TITLE
Upgrade the teradata driver to resolve electron memory issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+# 0.7.0
+
+- Update the teradata driver to version 20.0.20 which fixes memory conflicts with Electron. External node.js instance is no longer required.
+
 # 0.6.0
 
 - Fix native libraries needed by the Teradata driver.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 # SQLTools Teradata Driver
 
->[!IMPORTANT]
-> To use this extension in VS Code 1.77 and above, set `sqltools.useNodeRuntime` setting to `true`. 
-> Without the setting, the extension will not initialize as the database driver will fail to load and throw a native error instead.
-
 This SQLTools-based extension supports Teradata databases. Using this extension you can browse databases, tables, views, run queries, export results to CSV and JSON files. Stay connected to multiple Teradata instances at the same time. View query history, bookmark frequently used queries. The extension supports multiple authentication mechanisms including: native database, LDAP, TDNEGO and Kerberos. 
 
 ![](https://raw.githubusercontent.com/scriptpup/sqltools-teradata-driver/master/resources/preview-sqltools-teradata-driver.gif)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqltools-teradata-driver",
-  "version": "0.4.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sqltools-teradata-driver",
-      "version": "0.4.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@sqltools/base-driver": "latest",
@@ -28,6 +28,9 @@
       "engines": {
         "vscode": ">=1.61.0"
       }
+    },
+    "^20.0.10": {
+      "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -2322,31 +2325,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/array-index": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
-      "integrity": "sha512-jesyNbBkLQgGZMSwA1FanaFjalb1mZUGxGeUEkSDidzgrbjBGhvizJkaItdhkt8eIHFOJC7nDsrXk+BaehTdRw==",
-      "dependencies": {
-        "debug": "^2.2.0",
-        "es6-symbol": "^3.0.2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/array-index/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/array-index/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2789,15 +2767,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -3035,39 +3004,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -3111,19 +3047,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "dependencies": {
-        "type": "^2.7.2"
-      }
-    },
-    "node_modules/ext/node_modules/type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
-    },
     "node_modules/fast-redact": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
@@ -3143,23 +3066,6 @@
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/ffi-napi": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
-      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-uv-event-loop-napi-h": "^1.0.5",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1",
-        "ref-napi": "^2.0.1 || ^3.0.2",
-        "ref-struct-di": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/flatstr": {
@@ -3256,19 +3162,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-symbol-from-current-process-h": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
-      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
-    },
-    "node_modules/get-uv-event-loop-napi-h": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
-      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
-      "dependencies": {
-        "get-symbol-from-current-process-h": "^1.0.1"
       }
     },
     "node_modules/github-from-package": {
@@ -3757,6 +3650,13 @@
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "optional": true
     },
+    "node_modules/koffi": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.9.1.tgz",
+      "integrity": "sha512-LXYOzaiUB8XK7EwbG0tgzhajEr3FLS2RB9oHYbTOiWRQQO+Rgft3xSvd5TFlM3wQ6DMMQG41lvUR5gLgdyWIsA==",
+      "hasInstallScript": true,
+      "license": "MIT"
+    },
     "node_modules/leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -4125,11 +4025,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
     "node_modules/node-abi": {
       "version": "3.64.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.64.0.tgz",
@@ -4154,11 +4049,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
-    },
     "node_modules/node-gyp": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
@@ -4181,16 +4071,6 @@
       },
       "engines": {
         "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-gyp/node_modules/lru-cache": {
@@ -4615,54 +4495,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/ref-array-di": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ref-array-di/-/ref-array-di-1.2.2.tgz",
-      "integrity": "sha512-jhCmhqWa7kvCVrWhR/d7RemkppqPUdxEil1CtTtm7FkZV8LcHHCK3Or9GinUiFP5WY3k0djUkMvhBhx49Jb2iA==",
-      "dependencies": {
-        "array-index": "^1.0.0",
-        "debug": "^3.1.0"
-      }
-    },
-    "node_modules/ref-array-di/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/ref-napi": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.3.tgz",
-      "integrity": "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-symbol-from-current-process-h": "^1.0.2",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
-    "node_modules/ref-struct-di": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
-      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
-      "dependencies": {
-        "debug": "^3.1.0"
-      }
-    },
-    "node_modules/ref-struct-di/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/regenerate": {
@@ -5120,16 +4952,16 @@
       "dev": true
     },
     "node_modules/teradatasql": {
-      "version": "20.0.10",
-      "resolved": "https://registry.npmjs.org/teradatasql/-/teradatasql-20.0.10.tgz",
-      "integrity": "sha512-/O+th4IlEMyyqkXzEZoC5fXsgh6kOwZYnH25bxab3NnwBnYB0jtaJlWK0bI77/0h8RDDTPgE1U+nbZ1aWQYA8Q==",
+      "version": "20.6.17",
+      "resolved": "file:teradatasql-koffi-20.6.17.tgz",
+      "integrity": "sha512-jx0aps1vhbdeGU4WmnWWzmYPuQP4qEyfSV3vCp0Y4hFEbNwtXP8bw+45wlommk3lpuN+TUAIMG/q/UI04fLrSA==",
+      "license": "Teradata License Agreement",
       "dependencies": {
-        "ffi-napi": "^4.0.3",
-        "ref-array-di": "^1.2.2",
+        "koffi": "^2.9.0",
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/teradatasql/node_modules/uuid": {
@@ -5140,6 +4972,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -5185,11 +5018,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "node_modules/typed-rest-client": {
       "version": "1.8.11",
@@ -7087,30 +6915,6 @@
         "mri": "1.1.4"
       }
     },
-    "array-index": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
-      "integrity": "sha512-jesyNbBkLQgGZMSwA1FanaFjalb1mZUGxGeUEkSDidzgrbjBGhvizJkaItdhkt8eIHFOJC7nDsrXk+BaehTdRw==",
-      "requires": {
-        "debug": "^2.2.0",
-        "es6-symbol": "^3.0.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        }
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -7424,15 +7228,6 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
     },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -7599,35 +7394,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
-    "es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "requires": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -7656,21 +7422,6 @@
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "optional": true
     },
-    "ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "requires": {
-        "type": "^2.7.2"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
-        }
-      }
-    },
     "fast-redact": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
@@ -7687,19 +7438,6 @@
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "requires": {
         "pend": "~1.2.0"
-      }
-    },
-    "ffi-napi": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
-      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
-      "requires": {
-        "debug": "^4.1.1",
-        "get-uv-event-loop-napi-h": "^1.0.5",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1",
-        "ref-napi": "^2.0.1 || ^3.0.2",
-        "ref-struct-di": "^1.1.0"
       }
     },
     "flatstr": {
@@ -7775,19 +7513,6 @@
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
-      }
-    },
-    "get-symbol-from-current-process-h": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
-      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
-    },
-    "get-uv-event-loop-napi-h": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
-      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
-      "requires": {
-        "get-symbol-from-current-process-h": "^1.0.1"
       }
     },
     "github-from-package": {
@@ -8157,6 +7882,11 @@
         }
       }
     },
+    "koffi": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.9.1.tgz",
+      "integrity": "sha512-LXYOzaiUB8XK7EwbG0tgzhajEr3FLS2RB9oHYbTOiWRQQO+Rgft3xSvd5TFlM3wQ6DMMQG41lvUR5gLgdyWIsA=="
+    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -8453,11 +8183,6 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true
     },
-    "next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
     "node-abi": {
       "version": "3.64.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.64.0.tgz",
@@ -8474,11 +8199,6 @@
           "optional": true
         }
       }
-    },
-    "node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
     },
     "node-gyp": {
       "version": "8.4.1",
@@ -8523,11 +8243,6 @@
           "dev": true
         }
       }
-    },
-    "node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
     },
     "node-releases": {
       "version": "2.0.10",
@@ -8831,54 +8546,6 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
-      }
-    },
-    "ref-array-di": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ref-array-di/-/ref-array-di-1.2.2.tgz",
-      "integrity": "sha512-jhCmhqWa7kvCVrWhR/d7RemkppqPUdxEil1CtTtm7FkZV8LcHHCK3Or9GinUiFP5WY3k0djUkMvhBhx49Jb2iA==",
-      "requires": {
-        "array-index": "^1.0.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "ref-napi": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.3.tgz",
-      "integrity": "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==",
-      "requires": {
-        "debug": "^4.1.1",
-        "get-symbol-from-current-process-h": "^1.0.2",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1"
-      }
-    },
-    "ref-struct-di": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
-      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
-      "requires": {
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "regenerate": {
@@ -9213,12 +8880,10 @@
       }
     },
     "teradatasql": {
-      "version": "20.0.10",
-      "resolved": "https://registry.npmjs.org/teradatasql/-/teradatasql-20.0.10.tgz",
-      "integrity": "sha512-/O+th4IlEMyyqkXzEZoC5fXsgh6kOwZYnH25bxab3NnwBnYB0jtaJlWK0bI77/0h8RDDTPgE1U+nbZ1aWQYA8Q==",
+      "version": "20.6.17",
+      "integrity": "sha512-jx0aps1vhbdeGU4WmnWWzmYPuQP4qEyfSV3vCp0Y4hFEbNwtXP8bw+45wlommk3lpuN+TUAIMG/q/UI04fLrSA==",
       "requires": {
-        "ffi-napi": "^4.0.3",
-        "ref-array-di": "^1.2.2",
+        "koffi": "^2.9.0",
         "uuid": "^9.0.0"
       },
       "dependencies": {
@@ -9258,11 +8923,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "typed-rest-client": {
       "version": "1.8.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@sqltools/base-driver": "latest",
         "@sqltools/types": "latest",
         "@vscode/vsce": "^2.27.0",
-        "teradatasql": "^20.0.10",
+        "teradatasql": "^20.0.20",
         "uuid": "^7.0.2"
       },
       "devDependencies": {
@@ -4952,16 +4952,15 @@
       "dev": true
     },
     "node_modules/teradatasql": {
-      "version": "20.6.17",
-      "resolved": "file:teradatasql-koffi-20.6.17.tgz",
-      "integrity": "sha512-jx0aps1vhbdeGU4WmnWWzmYPuQP4qEyfSV3vCp0Y4hFEbNwtXP8bw+45wlommk3lpuN+TUAIMG/q/UI04fLrSA==",
-      "license": "Teradata License Agreement",
+      "version": "20.0.20",
+      "resolved": "https://registry.npmjs.org/teradatasql/-/teradatasql-20.0.20.tgz",
+      "integrity": "sha512-HYXZRSvF9/1Cuquf/1lknXl+hxUc46lyhAbnh6F6o63jv+88uVeoSsJnPvdJqZjHY0D0l7YVOU1obGo50h092w==",
       "dependencies": {
         "koffi": "^2.9.0",
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.20.2"
       }
     },
     "node_modules/teradatasql/node_modules/uuid": {
@@ -8880,8 +8879,9 @@
       }
     },
     "teradatasql": {
-      "version": "20.6.17",
-      "integrity": "sha512-jx0aps1vhbdeGU4WmnWWzmYPuQP4qEyfSV3vCp0Y4hFEbNwtXP8bw+45wlommk3lpuN+TUAIMG/q/UI04fLrSA==",
+      "version": "20.0.20",
+      "resolved": "https://registry.npmjs.org/teradatasql/-/teradatasql-20.0.20.tgz",
+      "integrity": "sha512-HYXZRSvF9/1Cuquf/1lknXl+hxUc46lyhAbnh6F6o63jv+88uVeoSsJnPvdJqZjHY0D0l7YVOU1obGo50h092w==",
       "requires": {
         "koffi": "^2.9.0",
         "uuid": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@sqltools/base-driver": "latest",
     "@sqltools/types": "latest",
     "@vscode/vsce": "^2.27.0",
-    "teradatasql": "^20.0.10",
+    "teradatasql": "^20.0.20",
     "uuid": "^7.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sqltools-teradata-driver",
   "displayName": "SQLTools Teradata Driver",
   "description": "VSCode SQLTools teradata driver",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "engines": {
     "vscode": ">=1.61.0"
   },


### PR DESCRIPTION
This PR upgrades the teradata driver to version 20.0.20. This driver resolves the memory management issues that the current version has with Electron. The upgrade eliminates the need to delegate execution to an external node.js process.